### PR TITLE
Fixed some tests

### DIFF
--- a/t/200_app/01_extended.t
+++ b/t/200_app/01_extended.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use t::Util;
-use Test::Requires 'HTTP::MobileAgent', 'HTTP::Session', 'Text::MicroTemplate::Extended', 'Amon2::Plugin::LogDispatch', 'Log::Dispatch', 'Tiffany';
+use Test::Requires 'HTTP::MobileAgent', 'HTTP::Session', 'Text::MicroTemplate::Extended', 'Amon2::Plugin::LogDispatch', 'Log::Dispatch', 'Tiffany', 'Amon2::MobileJP';
 
 $ENV{PLACK_ENV} = 'development';
 

--- a/t/300_setup/05_dotcloud.t
+++ b/t/300_setup/05_dotcloud.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use utf8;
 use Test::More;
+use Test::Requires +{ 'YAML::Tiny' => '1.46' };
 use t::TestFlavor;
 
 test_flavor(sub {


### PR DESCRIPTION
Amon2をcpanmしてみたら通らないテストがあったので修正してみました。よろしくご検討ください。
- t/200_app/01_extended.t
- t/300_setup/05_dotcloud.t

t/200_app/01_extended.tは、Test::Requiresでの指定にAmon2::MobileJPが入っていなくて失敗していたので、追加しました。

t/300_setup/05_dotcloud.tについては、以下のようなYAML::Tinyのバージョン違いによって通らなかったりするようなので、1.46以上をTest::Requiresで指定するようにしました。
- 1.44: NG
- 1.46: OK
# t/200_app/01_extended.tのエラー

```
t/200_app/01_extended.t .................... Error while loading Extended.psgi: Can't locate Amon2/Plugin/Web/MobileAgent.pm in @INC (@INC contains: /Users/antipop/dev/github/Amon/t/apps/Extended/lib /Users/antipop/dev/github/Amon/t/../lib /Users/antipop/dev/github/Amon/inc /Users/antipop/dev/github/Amon/blib/lib /Users/antipop/dev/github/Amon/blib/arch /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/5.8.8/darwin-2level /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/5.8.8 /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8/darwin-2level /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8 /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl .) at /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8/Plack/Util.pm line 22.
Compilation failed in require at Extended.psgi line 2.
BEGIN failed--compilation aborted at Extended.psgi line 2.
Error while loading Extended.psgi: Can't locate Amon2/Plugin/Web/MobileAgent.pm in @INC (@INC contains: /Users/antipop/dev/github/Amon/t/apps/Extended/lib /Users/antipop/dev/github/Amon/t/../lib /Users/antipop/dev/github/Amon/inc /Users/antipop/dev/github/Amon/blib/lib /Users/antipop/dev/github/Amon/blib/arch /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/5.8.8/darwin-2level /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/5.8.8 /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8/darwin-2level /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8 /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl .) at /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8/Plack/Util.pm line 22.
Compilation failed in require at Extended.psgi line 2.
BEGIN failed--compilation aborted at Extended.psgi line 2.
Can't locate Amon2/Plugin/Web/MobileAgent.pm in @INC (@INC contains: /Users/antipop/dev/github/Amon/t/apps/Extended/lib /Users/antipop/dev/github/Amon/t/../lib /Users/antipop/dev/github/Amon/inc /Users/antipop/dev/github/Amon/blib/lib /Users/antipop/dev/github/Amon/blib/arch /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/5.8.8/darwin-2level /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/5.8.8 /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8/darwin-2level /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8 /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl .) at /Users/antipop/perl5/perlbrew/perls/5.8.8/lib/site_perl/5.8.8/Plack/Util.pm line 22.
Compilation failed in require at t/03_session.t line 7.
BEGIN failed--compilation aborted at t/03_session.t line 7.
t/200_app/01_extended.t .................... 1/?
#   Failed test at t/Util.pm line 23.
# Looks like you failed 1 test of 1.
t/200_app/01_extended.t .................... Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/1 subtests
```
# t/300_setup/05_dotcloud.tのエラー

```
t/300_setup/05_dotcloud.t .................. 1/?
#   Failed test 'valid yaml file'
#   at t/07_dotcloud.t line 6.
# YAML::Tiny failed to classify line '  perl' at t/07_dotcloud.t line 5
# Looks like you failed 1 test of 1.

#   Failed test at t/TestFlavor.pm line 37.
# Looks like you failed 1 test of 2.
t/300_setup/05_dotcloud.t .................. Dubious, test returned 1 (wstat 256, 0x100)
Failed 1/2 subtests
```
