### PR TITLE
fix ignored db/.gitignore

### DIFF
--- a/lib/Amon2/Setup/Flavor/Basic.pm
+++ b/lib/Amon2/Setup/Flavor/Basic.pm
@@ -294,6 +294,7 @@ sub setup_schema {
 
     $self->write_file('db/.gitignore', <<'...');
 *
+!.gitignore
 ...
 
     for my $env (qw(development deployment test)) {


### PR DESCRIPTION
Basic Flavorでsetupした時に、db/.gitignoreがgitに無視されてしまってcloneした時にdbが作成されないので、.gitignore自体は無視しないように修正してみました。

よろしくお願いします。
