### PR TITLE
csrf_token hidden tag add only when method is POST

### DIFF
--- a/lib/Amon2/Plugin/Web/CSRFDefender.pm
+++ b/lib/Amon2/Plugin/Web/CSRFDefender.pm
@@ -21,10 +21,12 @@ our $ERROR_HTML = <<'...';
 sub init {
     my ($class, $c, $conf) = @_;
 
+    my $form_regexp = $conf->{post_only} ? qr{<form\s*.*?\s*method=['"]?post['"]?\s*.*?>}is : qr{<form\s*.*?>}is;
+
     $c->add_trigger(
         HTML_FILTER => sub {
             my ($self, $html) = @_;
-            $html =~ s!(<form\s*.*?\s*method=['"]?post['"]?\s*.*?>)!qq{$1\n<input type="hidden" name="csrf_token" value="}.$self->get_csrf_defender_token().qq{" />}!isge;
+            $html =~ s!($form_regexp)!qq{$1\n<input type="hidden" name="csrf_token" value="}.$self->get_csrf_defender_token().qq{" />}!ge;
             return $html;
         },
     );


### PR DESCRIPTION
form が method="post" の場合だけ、csrf_token の hidden タグを埋めて欲しいなと思ったのですが、
どうでしょうか？

method="get" の場合に csrf_token が埋まると http://.../?csrf_token=**\* みたいになるので。
