### PR TITLE
handle absolute URI

### DIFF
--- a/lib/Amon2/Web.pm
+++ b/lib/Amon2/Web.pm
@@ -151,7 +151,12 @@ sub uri_for {
         $val = URI::Escape::uri_escape(Encode::encode($self->encoding, $val));
         push @q, "${key}=${val}";
     }
-    $root . $path . (scalar @q ? '?' . join('&', @q) : '');
+    my $path_query = $root . $path . (scalar @q ? '?' . join('&', @q) : '');
+
+    my $uri = $self->req->uri->clone;
+    $uri->path_query($path_query);
+
+    return $uri;
 }
 
 sub render {

--- a/t/100_core/009_uri_for.t
+++ b/t/100_core/009_uri_for.t
@@ -23,12 +23,14 @@ use Amon2;
 my $req = Amon2::Web::Request->new({
     QUERY_STRING   => 'foo=%E3%81%BB%E3%81%92&bar=%E3%81%B5%E3%81%8C1&bar=%E3%81%B5%E3%81%8C2',
     REQUEST_METHOD => 'GET',
-    SCRIPT_NAME => '/foo/',
+    SCRIPT_NAME    => '/foo/',
+    HTTP_HOST      => 'localhost',
 });
 my $c = MyApp::Web->new(request => $req);
 
 my $uri = $c->uri_for('/bar/', {'boo' => 'ジョン'});
-is $uri, '/foo/bar/?boo=%E3%82%B8%E3%83%A7%E3%83%B3';
+is $uri->path_query, '/foo/bar/?boo=%E3%82%B8%E3%83%A7%E3%83%B3';
+is $uri, 'http://localhost/foo/bar/?boo=%E3%82%B8%E3%83%A7%E3%83%B3';
 is decode_utf8(+{URI->new($uri)->query_form}->{'boo'}), 'ジョン';
 
 done_testing;


### PR DESCRIPTION
uri_for() returns absolute URI instance.
old uri_for() == new uri_for()->path_query, now.

should i rename old uri_for() to path_query_for(), and create new uri_for() ?
