### PR TITLE
Flavor::Large: fix warning about Plack::App::File on Plack(>= 1.0017)

### DIFF
--- a/lib/Amon2/Setup/Flavor/Large.pm
+++ b/lib/Amon2/Setup/Flavor/Large.pm
@@ -71,7 +71,7 @@ builder {
             httponly => 1,
         );
 
-    mount '/static/' => Plack::App::File->new(root => File::Spec->catdir($basedir, 'static', 'pc'));
+    mount '/static/' => Plack::App::File->new(root => File::Spec->catdir($basedir, 'static', 'pc'))->to_app();
     mount '/' => <% $module %>::PC->to_app();
 };
 ...
@@ -116,7 +116,7 @@ builder {
             }
         );
 
-    mount '/static/' => Plack::App::File->new(root => File::Spec->catdir($basedir, 'static', 'admin'));
+    mount '/static/' => Plack::App::File->new(root => File::Spec->catdir($basedir, 'static', 'admin'))->to_app();
     mount '/' => <% $module %>::Admin->to_app();
 };
 ...

--- a/t/300_setup/06_large.t
+++ b/t/300_setup/06_large.t
@@ -59,6 +59,17 @@ sub error {
         };
     }
 
+    for my $type (qw(pc admin)) {
+        my $f = "${type}.psgi";
+        my $buff = << "...";
+\$SIG{__WARN__} = sub { die 'Warned! ' . shift };
+@{[slurp($f)]}
+...
+        open my $fh, '>', $f;
+        print $fh $buff;
+        close $fh;
+    }
+
     my $app = Plack::Util::load_psgi('app.psgi');
     my $mech = Test::WWW::Mechanize::PSGI->new(app => $app);
     {


### PR DESCRIPTION
in "Large" flavor and Plack (>= 1.0017), following warning appears:

`WARNING: Automatically converting Plack::App::File instance to a PSGI code reference. If you see this warning for each request, you probably need to explicitly call to_app() i.e. Plack::App::File->new(...)->to_app in your PSGI file.`

so I added `->to_app()` to `Plack::App::File->new(...)`.
