### PR TITLE
cpanfile uses comma instead of fat comma

### DIFF
--- a/t/300_setup/02_basic.t
+++ b/t/300_setup/02_basic.t
@@ -29,7 +29,7 @@ test_flavor(sub {
         };
     };
     is( scalar( my @files = glob('static/js/jquery-*.js') ), 1 );
-	like(slurp('cpanfile'), qr{'Amon2::DBI'\s+=>\s*'[0-9.]+'});
+	like(slurp('cpanfile'), qr{'Amon2::DBI'\s+,\s*'[0-9.]+'});
 }, 'Basic');
 
 done_testing;


### PR DESCRIPTION
5b92a3e7c600845b5689d40519c77c49f3bf5ae9

Amon2 3.81 tests are failed.
Please see this patch.
