### PR TITLE
fix a test checking whether jshint(1) exists or not

### DIFF
--- a/lib/Amon2/Setup/Flavor/Basic.pm
+++ b/lib/Amon2/Setup/Flavor/Basic.pm
@@ -419,7 +419,7 @@ use Test::Requires 'Text::SimpleTable';
 use File::Basename;
 
 plan skip_all => 'this test requires "jshint" command'
-  unless `jshint --version` =~ /\d/;
+  if system("jshint --version") != 0;
 
 my @files = (<static/*/*.js>, <static/*/*/*.js>, <static/*/*/*/*.js>);
 


### PR DESCRIPTION
because `jshint --version` outputs its version to stderr
