### PR TITLE
Make Starlet a dependency for the Standalone flavor.

### DIFF
--- a/lib/Amon2/Setup/Flavor/Standalone.pm
+++ b/lib/Amon2/Setup/Flavor/Standalone.pm
@@ -11,6 +11,17 @@ sub psgi_file {
     return 'script/' . lc($self->{dist}) . '-server';
 }
 
+sub create_makefile_pl {
+    my ($self, $prereq_pm) = @_;
+
+    $self->SUPER::create_makefile_pl(
+        +{
+            %{ $prereq_pm || {} },
+            'Starlet' => '0.19',
+        },
+    );
+}
+
 sub run {
     my $self = shift;
     $self->SUPER::run();


### PR DESCRIPTION
The startup script generated for the Standalone flavor loads Starlet to
run. However the module is not listed in the cpanfile. Add it.
