### PR TITLE
Fix modules passed to Test::Requires

### DIFF
--- a/t/300_setup/07_run_cli_server.t
+++ b/t/300_setup/07_run_cli_server.t
@@ -5,7 +5,7 @@ use Test::More;
 use Test::TCP;
 use Amon2::Setup::Flavor::Minimum;
 use File::Temp;
-use Test::Requires 'File::pushd', 'Furl';
+use Test::Requires 'File::pushd', 'Furl', 'Module::Functions', 'Starlet';
 
 my $tmpdir = File::Temp::tempdir( CLEANUP => 1 );
 {


### PR DESCRIPTION
Because Minimum flavor requires 'Starlet' and 'Module::Functions'
