### PR TITLE
QuickFix : dependency cycle in csrf_defender tests.

### DIFF
--- a/t/600_plugins/009_csrf_defender.t
+++ b/t/600_plugins/009_csrf_defender.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 use Plack::Request;
 use Plack::Test;
-use Test::Requires 'Test::WWW::Mechanize::PSGI', 'HTTP::Session::Store::OnMemory', 'Plack::Session', 'Amon2::Plugin::Web::CSRFDefender';
+use Test::Requires 'Test::WWW::Mechanize::PSGI', 'HTTP::Session::Store::OnMemory', 'Plack::Session', 'Amon2::Plugin::Web::CSRFDefender', 'Amon2::Plugin::Web::HTTPSession';
 use Plack::Builder;
 
 my $COMMIT;

--- a/t/600_plugins/011_csrf_defender_manual.t
+++ b/t/600_plugins/011_csrf_defender_manual.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 use Plack::Request;
 use Plack::Test;
-use Test::Requires 'Test::WWW::Mechanize::PSGI', 'HTTP::Session::Store::OnMemory', 'Plack::Session', 'Data::Section::Simple', 'Amon2::Lite', 'Amon2::Plugin::Web::CSRFDefender';
+use Test::Requires 'Test::WWW::Mechanize::PSGI', 'HTTP::Session::Store::OnMemory', 'Plack::Session', 'Data::Section::Simple', 'Amon2::Lite', 'Amon2::Plugin::Web::CSRFDefender', 'Amon2::Plugin::Web::HTTPSession';
 use Plack::Builder;
 
 our $COMMIT;

--- a/t/600_plugins/014_csrf_defender_post_only.t
+++ b/t/600_plugins/014_csrf_defender_post_only.t
@@ -5,7 +5,7 @@ use Plack::Request;
 use Plack::Test;
 use Test::Requires 'Test::WWW::Mechanize::PSGI',
   'HTTP::Session::Store::OnMemory', 'Plack::Session', 'Data::Section::Simple',
-  'Amon2::Lite', 'Amon2::Plugin::Web::CSRFDefender';
+  'Amon2::Lite', 'Amon2::Plugin::Web::CSRFDefender', 'Amon2::Plugin::Web::HTTPSession';
 use Plack::Builder;
 
 our $COMMIT;


### PR DESCRIPTION
Those tests require A::P::Web::HTTPSession. Bu this distribution needs
Amon2.

For now, just skip the tests if the plugin is not installed. This is a
quick fix until I can find a clean solution to still have the
CRSFDefender features properly tested.
