### PR TITLE
Remove all reference to the Web::HTTPSession plugin in tests.

### DIFF
--- a/t/600_plugins/009_csrf_defender.t
+++ b/t/600_plugins/009_csrf_defender.t
@@ -3,7 +3,7 @@ use warnings;
 use Test::More;
 use Plack::Request;
 use Plack::Test;
-use Test::Requires 'Test::WWW::Mechanize::PSGI', 'HTTP::Session::Store::OnMemory', 'Plack::Session', 'Amon2::Plugin::Web::CSRFDefender', 'Amon2::Plugin::Web::HTTPSession';
+use Test::Requires 'Test::WWW::Mechanize::PSGI', 'Plack::Session', 'Amon2::Plugin::Web::CSRFDefender';
 use Plack::Builder;
 
 my $COMMIT;
@@ -55,16 +55,6 @@ my $COMMIT;
         'Web::CSRFDefender' => {},
     );
 
-    package MyApp::Web::HTTPSession;
-    our @ISA = qw/MyApp::Web/;
-
-    __PACKAGE__->load_plugins(
-        'Web::HTTPSession' => {
-            state => 'Cookie',
-            store => sub { $session },
-        },
-    );
-
     package MyApp::Web::PlackSession;
     our @ISA = qw/MyApp::Web/;
 
@@ -73,48 +63,46 @@ my $COMMIT;
     );
 }
 
-for my $klass (qw/MyApp::Web::HTTPSession MyApp::Web::PlackSession/) {
-    my $app = builder {
-        enable 'Session';
-        $klass->to_app;
+my $app = builder {
+    enable 'Session';
+    MyApp::Web::PlackSession->to_app;
+};
+subtest 'MyApp::Web::PlackSession' => sub {
+    $COMMIT = 0;
+    subtest 'success case' => sub {
+        my $mech = Test::WWW::Mechanize::PSGI->new(
+            app => $app,
+        );
+        $mech->get_ok('http://localhost/form');
+        $mech->content_like(qr[<input type="hidden" name="csrf_token" value="[a-zA-Z0-9_]{32}" />]);
+        $mech->submit_form(form_number => 1, fields => {body => 'yay'});
+        is $mech->base, 'http://localhost/finished';
+        is $COMMIT, 1;
     };
-    subtest $klass => sub {
-        $COMMIT = 0;
-        subtest 'success case' => sub {
-            my $mech = Test::WWW::Mechanize::PSGI->new(
-                app => $app,
-            );
-            $mech->get_ok('http://localhost/form');
-            $mech->content_like(qr[<input type="hidden" name="csrf_token" value="[a-zA-Z0-9_]{32}" />]);
-            $mech->submit_form(form_number => 1, fields => {body => 'yay'});
-            is $mech->base, 'http://localhost/finished';
-            is $COMMIT, 1;
-        };
 
-        $COMMIT = 0;
-        subtest 'deny' => sub {
-            test_psgi
-                app => $app,
-                client => sub {
-                    my $cb = shift;
-                    my $res = $cb->(HTTP::Request->new(POST => 'http://localhost/do'));
-                    is $res->code, '403';
-                    is $COMMIT, 0;
-                };
-        };
-
-        subtest 'get_csrf_defender_token' => sub {
-            test_psgi
-                app => $app,
-                client => sub {
-                    my $cb = shift;
-                    my $res = $cb->(HTTP::Request->new(GET => 'http://localhost/get_csrf_defender_token'));
-                    is $res->code, '200';
-                    ::like $res->content(), qr{^[a-zA-Z0-9_]{32}$};
-                };
-        };
+    $COMMIT = 0;
+    subtest 'deny' => sub {
+        test_psgi
+            app => $app,
+            client => sub {
+                my $cb = shift;
+                my $res = $cb->(HTTP::Request->new(POST => 'http://localhost/do'));
+                is $res->code, '403';
+                is $COMMIT, 0;
+            };
     };
-}
+
+    subtest 'get_csrf_defender_token' => sub {
+        test_psgi
+            app => $app,
+            client => sub {
+                my $cb = shift;
+                my $res = $cb->(HTTP::Request->new(GET => 'http://localhost/get_csrf_defender_token'));
+                is $res->code, '200';
+                ::like $res->content(), qr{^[a-zA-Z0-9_]{32}$};
+            };
+    };
+};
 
 done_testing;
 

--- a/t/600_plugins/014_csrf_defender_post_only.t
+++ b/t/600_plugins/014_csrf_defender_post_only.t
@@ -4,25 +4,19 @@ use Test::More;
 use Plack::Request;
 use Plack::Test;
 use Test::Requires 'Test::WWW::Mechanize::PSGI',
-  'HTTP::Session::Store::OnMemory', 'Plack::Session', 'Data::Section::Simple',
-  'Amon2::Lite', 'Amon2::Plugin::Web::CSRFDefender', 'Amon2::Plugin::Web::HTTPSession';
+  'Plack::Session', 'Data::Section::Simple',
+  'Amon2::Lite', 'Amon2::Plugin::Web::CSRFDefender';
 use Plack::Builder;
 
 our $COMMIT;
 
-my $app = do {
-
+{
     package MyApp::Web;
     use Amon2::Lite;
 
     sub load_config { +{} }
 
-    my $session = HTTP::Session::Store::OnMemory->new();
     __PACKAGE__->load_plugins(
-        'Web::HTTPSession' => {
-            state => 'Cookie',
-            store => sub { $session },
-        },
         'Web::CSRFDefender',
         { post_only => 1 }
     );
@@ -56,8 +50,11 @@ my $app = do {
     get '/finished' => sub {
         Plack::Response->new( 200, [], ['Finished'] );
     };
+}
 
-    __PACKAGE__->to_app;
+my $app = builder {
+    enable 'Session';
+    MyApp::Web->to_app();
 };
 
 subtest 'post method' => sub {


### PR DESCRIPTION
This allows to test the Web::CSRFDefender plugin again.
