### PR TITLE
Amon2 switched to bootstrap v3, point to the new URL in the index template

### DIFF
--- a/share/flavor/Basic/tmpl/index.tx
+++ b/share/flavor/Basic/tmpl/index.tx
@@ -19,7 +19,7 @@
             <h2><i class="glyphicon glyphicon-ok"></i> CSS Library</h2>
             <div>
                 Current version of Amon2 using twitter's bootstrap.css as a default CSS library.<br />
-                If you want to learn it, please access to <a href="http://twitter.github.com/bootstrap/">twitter.github.com/bootstrap/</a>
+                If you want to learn it, please access to <a href="http://getbootstrap.com/">getbootstrap.com/</a>
             </div>
         </div>
 


### PR DESCRIPTION
minor change in  share/flavor/Basic/tmpl/index.tx
