### PR TITLE
5.10+ fails on perl-5.18.1: needs Router::Simple::Sinatraish

### DIFF
--- a/t/800_dispatcher/003_lite.t
+++ b/t/800_dispatcher/003_lite.t
@@ -1,7 +1,7 @@
 use strict;
 use warnings;
 use Test::More tests => 4;
-use Test::Requires 'Router::Simple';
+use Test::Requires 'Router::Simple', 'Router::Simple::Sinatraish';
 
 {
     package MyApp;


### PR DESCRIPTION
Seems like new Amon2 needs an explicit dep on Router::Simple::Sinatraish.

```
Can't locate Router/Simple/Sinatraish.pm in @INC

Compilation failed in require at t/800_dispatcher/003_lite.t line 18.
BEGIN failed--compilation aborted at t/800_dispatcher/003_lite.t line 18.
# Looks like your test exited with 2 before it could output anything.
t/800_dispatcher/003_lite.t ....................
```
