### PR TITLE
Resolve Text::Xslate: Undefined symbol 'pager'

### DIFF
--- a/share/flavor/Basic/tmpl/include/pager.tx
+++ b/share/flavor/Basic/tmpl/include/pager.tx
@@ -2,7 +2,7 @@
     <div class="pagination">
         <ul>
             <: if ($pager.previous_page) { :>
-                <li class="prev"><a href="<: uri_with({page => pager.previous_page}) :>" rel="previous">&larr; Back</a><li>
+                <li class="prev"><a href="<: uri_with({page => $pager.previous_page}) :>" rel="previous">&larr; Back</a><li>
             <: } else { :>
                 <li class="prev disabled"><a href="#">&larr; Back</a><li>
             <: } :>


### PR DESCRIPTION
Text::Xslate: Undefined symbol 'pager'というエラーがでていたのを修正しました。
２行バラバラのコミットになってかっこ悪くてすみません
