### PR TITLE
rename X-JSON-Status to X-API-status

### DIFF
--- a/lib/Amon2/Plugin/Web/JSON.pm
+++ b/lib/Amon2/Plugin/Web/JSON.pm
@@ -44,7 +44,7 @@ sub init {
             $res->body($output);
 
             if (defined (my $status_code_field =  $conf->{status_code_field})) {
-                $res->header( 'X-JSON-Status' => $stuff->{$status_code_field} ) if exists $stuff->{$status_code_field};
+                $res->header( 'X-API-Status' => $stuff->{$status_code_field} ) if exists $stuff->{$status_code_field};
             }
 
             return $res;
@@ -94,19 +94,19 @@ Generate JSON data from C<< \%dat >> and returns instance of L<Plack::Response>.
 
 =item status_code_field
 
-It specify the field name of JSON to be embedded in the 'X-JSON-Status' header.
-Default is C<< undef >>. If you set the C<< undef >> to disable this 'X-JSON-Status' header.
+It specify the field name of JSON to be embedded in the 'X-API-Status' header.
+Default is C<< undef >>. If you set the C<< undef >> to disable this 'X-API-Status' header.
 
     __PACKAGE__->load_plugins(
         'Web::JSON' => { status_code_field => 'status' }
     );
     ...
     $c->render_json({ status => 200, message => 'ok' })
-    # send response header 'X-JSON-Status: 200'
+    # send response header 'X-API-Status: 200'
 
 In general JSON API error code embed in a JSON by JSON API Response body.
 But can not be logging the error code of JSON for the access log of a general Web Servers.
-You can possible by using the 'X-JSON-Status' header.
+You can possible by using the 'X-API-Status' header.
 
 =back
 

--- a/t/600_plugins/007_json_x_api_status.t
+++ b/t/600_plugins/007_json_x_api_status.t
@@ -15,7 +15,7 @@ subtest 'default' => sub {
 
     my $res = $app->render_json({ status => 200 });
     is($res->code, 200);
-    is($res->header('X-JSON-Status'), undef);
+    is($res->header('X-API-Status'), undef);
     is $res->content, '{"status":200}';
 };
 
@@ -32,7 +32,7 @@ subtest 'set status_code_field = undef' => sub {
 
     my $res = $app->render_json({ status => 200 });
     is($res->code, 200);
-    is($res->header('X-JSON-Status'), undef);
+    is($res->header('X-API-Status'), undef);
     is $res->content, '{"status":200}';
 };
 
@@ -50,14 +50,14 @@ subtest 'set status_code_field = "error"' => sub {
     subtest 'not have a status_code_field' => sub {
         my $res = $app->render_json({});
         is($res->code, 200);
-        is($res->header('X-JSON-Status'), undef);
+        is($res->header('X-API-Status'), undef);
         is $res->content, '{}';
     };
 
     subtest 'have a status_code_field' => sub {
         my $res = $app->render_json({ error => 402 });
         is($res->code, 200);
-        is($res->header('X-JSON-Status'), '402');
+        is($res->header('X-API-Status'), '402');
         is $res->content, '{"error":402}';
     };
 };
@@ -76,14 +76,14 @@ subtest 'set status_code_field = ""' => sub {
     subtest 'not have a status_code_field' => sub {
         my $res = $app->render_json({});
         is($res->code, 200);
-        is($res->header('X-JSON-Status'), undef);
+        is($res->header('X-API-Status'), undef);
         is $res->content, '{}';
     };
 
     subtest 'have a status_code_field' => sub {
         my $res = $app->render_json({ '' => 402 });
         is($res->code, 200);
-        is($res->header('X-JSON-Status'), '402');
+        is($res->header('X-API-Status'), '402');
         is $res->content, '{"":402}';
     };
 };
@@ -102,14 +102,14 @@ subtest 'set status_code_field = "0"' => sub {
     subtest 'not have a status_code_field' => sub {
         my $res = $app->render_json({});
         is($res->code, 200);
-        is($res->header('X-JSON-Status'), undef);
+        is($res->header('X-API-Status'), undef);
         is $res->content, '{}';
     };
 
     subtest 'have a status_code_field' => sub {
         my $res = $app->render_json({ '0' => 402 });
         is($res->code, 200);
-        is($res->header('X-JSON-Status'), '402');
+        is($res->header('X-API-Status'), '402');
         is $res->content, '{"0":402}';
     };
 };


### PR DESCRIPTION
It was considered at the time to provide an API at the same time the format of the other.
