### PR TITLE
Added "use warnings" to "script/server.pl".

### DIFF
--- a/share/flavor/Minimum/script/server.pl
+++ b/share/flavor/Minimum/script/server.pl
@@ -1,5 +1,6 @@
 #!perl
 use strict;
+use warnings;
 use utf8;
 use File::Spec;
 use File::Basename;
@@ -51,6 +52,7 @@ unless (caller) {
             Carp::croak("$config_file does not return HashRef.");
         }
         no warnings 'redefine';
+        no warnings 'once';
         *<% $module %>::load_config = sub { $config }
     }
 


### PR DESCRIPTION
Since "no warnings 'redefine'" is specified, I think that it is better to add "use warnings" and "no warnings 'once'".
