### PR TITLE
Skip this test if 'sqlite3' is not installed

### DIFF
--- a/t/300_setup/06_large.t
+++ b/t/300_setup/06_large.t
@@ -17,6 +17,9 @@ use Test::Requires {
     'Plack::Middleware::ReverseProxy' => 0,
 };
 
+plan skip_all => 'this test requires "sqlite3" command'
+  if system("sqlite3 -version") != 0;
+
 test_flavor(sub {
     ok(!-e 'xxx');
     ok(!-e 'yyy');


### PR DESCRIPTION
This test is failed if `sqlite3` is not installed.
It is not enough to check whether `DBD::SQLite` is installed
because we can install `DBD::SQLite` without `sqlite3`.
