### PR TITLE
bug fix. by Large flavor, ViewFunctions::static_file

### DIFF
--- a/lib/Amon2/Setup/Flavor/Large.pm
+++ b/lib/Amon2/Setup/Flavor/Large.pm
@@ -141,8 +141,9 @@ sub run {
         $self->render_file("lib/<<PATH>>/$moniker.pm", 'Large/lib/__PATH__/__MONIKER__.pm', {moniker => $moniker});
         $self->render_file("lib/<<PATH>>/$moniker/Dispatcher.pm", 'Large/lib/__PATH__/__MONIKER__/Dispatcher.pm', {moniker => $moniker});
         $self->render_file("lib/<<PATH>>/$moniker/C/Root.pm", 'Large/lib/__PATH__/__MONIKER__/C/Root.pm', {moniker => $moniker});
-        $self->render_file( "lib/<<PATH>>/${moniker}/ViewFunctions.pm", 'Minimum/lib/__PATH__/Web/ViewFunctions.pm', {
-            package => "$self->{module}::${moniker}::ViewFunctions",
+        $self->render_file( "lib/<<PATH>>/${moniker}/ViewFunctions.pm", 'Large/lib/__PATH__/__MONIKER__/ViewFunctions.pm', {
+            moniker => $moniker, 
+            lc_moniker => lc($moniker)
         });
         $self->render_file( "lib/<<PATH>>/${moniker}/Plugin/Session.pm", 'Basic/lib/__PATH__/Web/Plugin/Session.pm', {
             package => "$self->{module}::${moniker}::Plugin::Session",

--- a/share/flavor/Large/lib/__PATH__/__MONIKER__/ViewFunctions.pm
+++ b/share/flavor/Large/lib/__PATH__/__MONIKER__/ViewFunctions.pm
@@ -1,0 +1,39 @@
+package <% $module %>::<% $moniker %>::ViewFunctions;
+use strict;
+use warnings;
+use utf8;
+use parent qw(Exporter);
+use Module::Functions;
+use File::Spec;
+
+our @EXPORT = get_public_functions();
+
+sub commify {
+    local $_  = shift;
+    1 while s/((?:\A|[^.0-9])[-+]?\d+)(\d{3})/$1,$2/s;
+    return $_;
+}
+
+sub c { <% $module %>->context() }
+sub uri_with { <% $module %>->context()->req->uri_with(@_) }
+sub uri_for { <% $module %>->context()->uri_for(@_) }
+
+{
+    my %static_file_cache;
+    sub static_file {
+        my $fname = shift;
+        (my $relpath = $fname) =~ s!static!static/<% $lc_moniker %>!;
+        my $c = <% $module %>->context;
+        if (not exists $static_file_cache{$relpath}) {
+            my $fullpath = File::Spec->catfile($c->base_dir(), $relpath);
+            $static_file_cache{$relpath} = (stat $fullpath)[9];
+        }
+        return $c->uri_for(
+            $fname, {
+                't' => $static_file_cache{$relpath} || 0
+            }
+        );
+    }
+}
+
+1;

--- a/t/300_setup/06_large.t
+++ b/t/300_setup/06_large.t
@@ -55,6 +55,7 @@ test_flavor(sub {
         my $mech = Test::WWW::Mechanize::PSGI->new(app => $app);
         my $res = $mech->get('http://localhost/');
         is($res->code, 200);
+        like($res->decoded_content,qr(static/css/main.css\?t=\d{10}),'fuction static_file success');
     };
 
     subtest 'admin' => sub {


### PR DESCRIPTION
static_file's input is in example, "/static/css/main.css".But setuped application's file path is:
- In Other Flavor, just ./static/css/main.css
- In Large Flavor, ./static/admin/css/main.css or ./static/web/css/main.css 

I can not get $fullpath in Large Flavor. So I fixed this point.
