### PR TITLE
#redirect accepts upper case url scheme, for robustness principle

### DIFF
--- a/lib/Amon2/Web.pm
+++ b/lib/Amon2/Web.pm
@@ -50,7 +50,7 @@ sub req               { $_[0]->{request} }
 sub redirect {
     my ($self, $location, $params) = @_;
     my $url = do {
-        if ($location =~ m{^https?://}) {
+        if ($location =~ m{^https?://}i) {
             $location;
         } else {
             my $url = $self->request->base;


### PR DESCRIPTION
especially for user input from smartphone which does auto capitalization
