### PR TITLE
Fix Amon2::Web::Response::Callback->finalize header validation.

### DIFF
--- a/lib/Amon2/Web/Response/Callback.pm
+++ b/lib/Amon2/Web/Response/Callback.pm
@@ -30,7 +30,7 @@ sub finalize {
         $code->(
             sub {
                 my @copy = @{ $_[0]->[1] };
-                for (my ($key, $val) = splice(@copy, 0, 2)) {
+                while (my (undef, $val) = splice(@copy, 0, 2)) {
                     if ($val =~ /[\000-\037]/) {
                         die("Response headers MUST NOT contain characters below octal \037\n");
                     }

--- a/t/100_core/002_response.t
+++ b/t/100_core/002_response.t
@@ -2,6 +2,7 @@ use strict;
 use warnings;
 use Test::More;
 use Amon2::Web::Response;
+use Amon2::Web::Response::Callback;
 
 my $res = Amon2::Web::Response->new(200, [], 'ok');
 $res->content_type('text/html');
@@ -10,4 +11,45 @@ $res->body('hoge');
 isa_ok $res, 'Amon2::Web::Response', 'method chain';
 is_deeply $res->finalize(), [403, ['Content-Type' => 'text/html'], ['hoge']];
 
+test_callback_finalize(
+  expected => [ 403, [ 'Content-Type' => 'text/html' ], [ 'hoge' ] ],
+  given => [ 403, [ 'Content-Type' => 'text/html' ], [ 'hoge' ] ],
+);
+
+test_callback_finalize(
+  dies => 1,
+  given => [ 403, [ 'Content-Type' => "text/html\r\n" ], [ 'hoge' ] ],
+);
+
+test_callback_finalize(
+  dies => 1,
+  given => [
+    403,
+    [ 'Content-Type' => 'text/html', 'Content-Length' => "42\r\n" ],
+    [ 'hoge' ],
+  ],
+);
+
 done_testing;
+
+sub test_callback_finalize {
+  my (%params) = @_;
+
+  my $dies = delete $params{dies};
+  my $expected = delete $params{expected};
+  my $given = delete $params{given};
+
+  my $cb_res = Amon2::Web::Response::Callback->new(
+    code => sub {
+      my ($respond) = @_;
+      $respond->($given);
+    },
+  );
+
+  my ($got) = eval { $cb_res->finalize->(sub { @_ }) };
+  if ($dies) {
+    ok $@, 'Error-expected operation returned a value.';
+  } else {
+    is_deeply $got, $expected;
+  }
+}


### PR DESCRIPTION
Amon2::Web::Response::Callback's header validation, for defending against HTTP response splitting attack, seems to be not exhausive.
In `finalize` method, `for` is mistakenly used where `while` should be used. So only first value of headers is validated as a result of it. I guess it can be vulnerability.