### PR TITLE
Switch setup templates to Plack::Middleware::Session + file store

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,6 +2,7 @@ Revision history for Perl module Amon2
 
 {{$NEXT}}
 
+    - Switch setup templates to use Plack::Middleware::Session with CSRF tests
     - Remove jshint test from generated projects
     - Remove unused Try::Tiny dependency
     - Drop Amon2::Plugin::Web::MobileAgent references and Extended example app

--- a/cpanfile
+++ b/cpanfile
@@ -25,7 +25,6 @@ requires 'URI::QueryParam';
 requires 'File::Copy::Recursive'; # setup script
 requires 'File::ShareDir';
 requires 'Module::CPANfile', '0.9020';
-requires 'HTTP::Session2';
 requires 'Crypt::SysRandom';
 requires 'MIME::Base64';
 
@@ -76,4 +75,3 @@ on test => sub {
     suggests 'Amon2::DBI';
     suggests 'Crypt::Rijndael';
 };
-

--- a/lib/Amon2/Setup/Flavor/Basic.pm
+++ b/lib/Amon2/Setup/Flavor/Basic.pm
@@ -40,9 +40,8 @@ sub run {
         'DBD::SQLite'                     => '1.33',
         'Test::WWW::Mechanize::PSGI'      => 0,
         'Router::Boom'                    => '0.06',
-        'HTTP::Session2'                  => '1.03',
-        'Crypt::CBC'                      => '0',
-        'Crypt::Rijndael'                 => '0',
+        'Plack::Middleware::Session'      => 0,
+        'Plack::Session::Store::File'     => 0,
     });
 
     # static files
@@ -73,6 +72,9 @@ sub run {
         psgi_file => $self->psgi_file,
     });
     $self->render_file( 't/03_assets.t',      'Basic/t/03_assets.t', {
+        psgi_file => $self->psgi_file,
+    });
+    $self->render_file( 't/04_csrf.t',        'Basic/t/04_csrf.t', {
         psgi_file => $self->psgi_file,
     });
     $self->render_file( 'xt/01_pod.t',    'Minimum/xt/01_pod.t' );

--- a/lib/Amon2/Setup/Flavor/Large.pm
+++ b/lib/Amon2/Setup/Flavor/Large.pm
@@ -78,6 +78,9 @@ sub run {
     $self->render_file( 't/04_admin.t',       'Large/t/04_admin.t', {
         psgi_file => $admin_script,
     });
+    $self->render_file( 't/05_csrf.t',        'Basic/t/04_csrf.t', {
+        psgi_file => $web_script,
+    });
     $self->render_file( 't/07_mech_links.t',  'Large/t/07_mech_links.t', {
         psgi_file => $web_script,
     });
@@ -95,15 +98,13 @@ sub run {
             'DBI'                                => 0,
             'File::ShareDir'                     => 0,
             'Getopt::Long'                       => 0,
-            'HTTP::Session2::ClientStore2'       => 0,
-            'Crypt::CBC'                         => '0',
-            'Crypt::Rijndael'                    => '0',
             'Module::Build'                      => 0,
             'Module::Find'                       => 0,        # load controllers
             'Module::Functions'                  => 2,        # Dispatcher
             'Plack::App::File'                   => 0,
             'Plack::Builder'                     => 0,
             'Plack::Loader'                      => 0,
+            'Plack::Middleware::Session'         => 0,
             'Plack::Middleware::ReverseProxy'    => 0,
             'Plack::Session::Store::DBI'         => 0,
             'Router::Boom'                       => '0.06',
@@ -202,4 +203,3 @@ Amon2::Setup::Flavor::Large - Flavor with admin pages
 =head1 DESCRIPTION
 
 This is an Amon2 flavor based on Amon2::Setup::Flavor::Basic.
-

--- a/share/flavor/Basic/script/server.pl
+++ b/share/flavor/Basic/script/server.pl
@@ -5,9 +5,13 @@ use <% $module %>::Web;
 use <% $module %>;
 use URI::Escape;
 use File::Path ();
+use Plack::Session::Store::File;
 %% }
 
 %% override app -> {
+my $session_dir = File::Spec->catdir(dirname(__FILE__), '..', 'tmp', 'session');
+File::Path::mkpath($session_dir);
+
 my $app = builder {
     enable 'Plack::Middleware::Static',
         path => qr{^(?:/static/)},
@@ -16,6 +20,10 @@ my $app = builder {
         path => qr{^(?:/robots\.txt|/favicon\.ico)$},
         root => File::Spec->catdir(dirname(__FILE__), '..', 'static');
     enable 'Plack::Middleware::ReverseProxy';
+    enable 'Plack::Middleware::Session',
+        store => Plack::Session::Store::File->new(
+            dir => $session_dir,
+        );
 
     <% $module %>::Web->to_app();
 };

--- a/share/flavor/Basic/t/04_csrf.t
+++ b/share/flavor/Basic/t/04_csrf.t
@@ -1,0 +1,55 @@
+use strict;
+use warnings;
+use utf8;
+use t::Util;
+use Plack::Test;
+use Plack::Util;
+use HTTP::Request::Common qw(GET POST);
+use Test::More;
+
+my $app = Plack::Util::load_psgi '<% $psgi_file // "app.psgi" %>';
+
+test_psgi
+    app => $app,
+    client => sub {
+        my $cb = shift;
+        my %cookies;
+
+        my $request = sub {
+            my ($req) = @_;
+            if (%cookies) {
+                my $cookie = join '; ', map { "$_=$cookies{$_}" } sort keys %cookies;
+                $req->header('Cookie' => $cookie);
+            }
+
+            my $res = $cb->($req);
+            for my $set_cookie ($res->headers->header('Set-Cookie')) {
+                my ($pair) = split /;/, $set_cookie, 2;
+                my ($name, $value) = split /=/, $pair, 2;
+                next unless defined $name && defined $value;
+                $cookies{$name} = $value;
+            }
+            return $res;
+        };
+
+        my $get_res = $request->(GET 'http://localhost/__csrf_probe__');
+        is $get_res->code, 404, 'GET probe path returns 404';
+        ok $cookies{'XSRF-TOKEN'}, 'XSRF-TOKEN cookie is issued';
+
+        my $post_no_token = $request->(POST 'http://localhost/reset_counter');
+        is $post_no_token->code, 403, 'POST without token is rejected';
+
+        my $post_bad_token = $request->(
+            POST 'http://localhost/reset_counter',
+            [ 'XSRF-TOKEN' => 'invalid-token' ]
+        );
+        is $post_bad_token->code, 403, 'POST with invalid token is rejected';
+
+        my $post_ok = $request->(
+            POST 'http://localhost/reset_counter',
+            [ 'XSRF-TOKEN' => $cookies{'XSRF-TOKEN'} ]
+        );
+        is $post_ok->code, 302, 'POST with valid token is accepted';
+    };
+
+done_testing;

--- a/t/300_setup/02_basic.t
+++ b/t/300_setup/02_basic.t
@@ -14,21 +14,21 @@ use Test::Requires +{
     'Module::Functions'               => '0',
     'HTML::FillInForm::Lite'          => 0,
     'Plack::Middleware::ReverseProxy' => 0,
-    'Crypt::CBC'                      => 0,
-    'HTTP::Session2::ClientStore2'    => 0,
-    'Crypt::Rijndael' => 0,
+    'Plack::Middleware::Session'      => 0,
+    'Plack::Session::Store::File'     => 0,
 };
 
 test_flavor(sub {
     ok(-f 'Build.PL', 'Build.PL');
-	like(slurp('cpanfile'), qr{HTTP::Session2});
+	like(slurp('cpanfile'), qr{Plack::Middleware::Session});
 	for my $env (qw(development production test)) {
 		ok(-f "./config/${env}.pl");
 		my $conf = do "./config/${env}.pl";
 		is(ref($conf), 'HASH');
 	}
     ok(-f './lib/My/App.pm', 'lib/My/App.pm exists');
-    like(slurp('./lib/My/App/Web/Plugin/Session.pm'), qr{secret => '.+'});
+    like(slurp('./lib/My/App/Web/Plugin/Session.pm'), qr{sub _validate_xsrf_token});
+    like(slurp('./script/my-app-server'), qr{Plack::Session::Store::File}, 'uses file session store');
     ok((do './lib/My/App.pm'), 'lib/My/App.pm is valid') or do {
         diag $@;
         diag do {
@@ -41,4 +41,3 @@ test_flavor(sub {
 }, 'Basic');
 
 done_testing;
-

--- a/t/300_setup/06_large.t
+++ b/t/300_setup/06_large.t
@@ -18,9 +18,7 @@ use Test::Requires {
     'HTML::FillInForm::Lite'          => 0,
     'Router::Boom'                    => '0.03',
     'Plack::Middleware::ReverseProxy' => 0,
-    'HTTP::Session2::ClientStore2'    => 0,
-    'Crypt::CBC'                      => 0,
-    'Crypt::Rijndael' => 0,
+    'Plack::Middleware::Session'      => 0,
 };
 
 plan skip_all => 'this test requires "sqlite3" command'
@@ -82,4 +80,3 @@ test_flavor(sub {
 }, 'Large');
 
 done_testing;
-


### PR DESCRIPTION
## Summary
- replace HTTP::Session2-based generated session handling with Plack::Middleware::Session-based flow in Basic/Large templates
- configure Basic flavor to use `Plack::Session::Store::File` by default (shared across Starlet workers)
- keep XSRF token validation/cookie behavior via generated session plugin methods
- add generated app CSRF behavior test template (`t/04_csrf.t`) and wire it into Basic/Large setup tests
- update setup flavor dependencies and tests accordingly

## Verification
- syntax checks:
  - `perl -Ilib -c lib/Amon2/Setup/Flavor/Basic.pm`
  - `perl -Ilib -c lib/Amon2/Setup/Flavor/Large.pm`
  - `perl -Ilib -c t/300_setup/02_basic.t`
  - `perl -Ilib -c t/300_setup/06_large.t`
- generated-app smoke verification in `/tmp` with local share override:
  - Basic generation includes `Plack::Session::Store::File` config
  - CSRF test template passes for generated Basic and Large apps (`t/04_csrf.t` / `t/05_csrf.t`)